### PR TITLE
Leave non-stylus sources alone, fixes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 const stylus = require('stylus')
 
 module.exports = function sheetifyStylus(filename, source, options, cb) {
-  options = Object.assign({}, options, {
-    filename
-  })
-  stylus.render(source, options, cb)
+  if (/\.styl$/.test(filename)) {
+    options = Object.assign({}, options, {
+      filename
+    })
+    stylus.render(source, options, cb)
+  } else {
+    cb(null, source)
+  }
 }


### PR DESCRIPTION
Ensure that sources are .styl before transforming them.
